### PR TITLE
Implement two patterns us --> uk

### DIFF
--- a/src/pattern.ts
+++ b/src/pattern.ts
@@ -114,10 +114,24 @@ const patterns:ReplacementPattern[] = [
 	},
 
 	{
+		regex:/eled$/,
+		originalIndex:[4],
+		replacementIndex:[0,5],
+		replacementString:"elled"
+	},
+
+	{
 		regex:/([cpviglnbmd])(our)(ed$|ing$|s$|al$|ally$|ful$|$)/,
 		originalIndex:[0],
 		replacementIndex:[4],
 		replacementString:"$1or$3"
+	},
+
+	{
+		regex:/([cpviglnbm])(or)(ed$|ing$|s$|al$|ally$|ful$|$)/,
+		originalIndex:[4],
+		replacementIndex:[0],
+		replacementString:"$1our$3"
 	},
 
 	{


### PR DESCRIPTION
It looks like when two additional patterns were added in 03890d2 the reverse (US --> UK) weren't added. Added them.

Note: The second set added is parallel to the immediately above but is missing the 'd' on purpose (otherwise a wide number of words that shouldn't match do - e.g. 'ambassador').
Causes misses on some words (e.g. 'odor').